### PR TITLE
add user ID extraction to AuthGlobalFilter

### DIFF
--- a/src/main/java/com/example/apigateway/filters/AuthGlobalFilter.java
+++ b/src/main/java/com/example/apigateway/filters/AuthGlobalFilter.java
@@ -82,8 +82,10 @@ public class AuthGlobalFilter implements GlobalFilter {
                     HttpHeaders authHeaders = authResponseEntity.getHeaders();
                     String userRoles = authHeaders.getFirst("X-User-Roles");
                     String userEmail = authHeaders.getFirst("X-User-Email");
+                    String userId = authHeaders.getFirst("X-User-Id");
 
-                    log.debug("Extracted headers - X-User-Roles: {}, X-User-Email: {}", userRoles, userEmail);
+                    log.debug("Extracted headers - X-User-Roles: {}, X-User-Email: {}, X-User-Id: {}", userRoles,
+                            userEmail, userId);
 
                     // 4. Mutate the original request to add the extracted headers
                     ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
@@ -94,6 +96,9 @@ public class AuthGlobalFilter implements GlobalFilter {
                                 }
                                 if (userEmail != null) {
                                     headers.add("X-User-Email", userEmail);
+                                }
+                                if (userId != null) {
+                                    headers.add("X-User-Id", userId);
                                 }
                                 // You could potentially add other headers here if needed
                             })


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `AuthGlobalFilter` class by adding support for extracting and propagating the `X-User-Id` header in the API Gateway. This change ensures that the `X-User-Id` header is logged and forwarded along with other user-related headers.

### Enhancements to header handling in `AuthGlobalFilter`:

* Added extraction of the `X-User-Id` header from the authentication response and included it in the debug log output. (`src/main/java/com/example/apigateway/filters/AuthGlobalFilter.java`, [src/main/java/com/example/apigateway/filters/AuthGlobalFilter.javaR85-R88](diffhunk://#diff-940970772cb35fb606952b0e76d2b9dd0938368f8f220c53ba523dc4996dd6d4R85-R88))
* Modified the request mutation logic to include the `X-User-Id` header in the forwarded headers if it is present. (`src/main/java/com/example/apigateway/filters/AuthGlobalFilter.java`, [src/main/java/com/example/apigateway/filters/AuthGlobalFilter.javaR100-R102](diffhunk://#diff-940970772cb35fb606952b0e76d2b9dd0938368f8f220c53ba523dc4996dd6d4R100-R102))